### PR TITLE
update to JDA 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 ![image](https://user-images.githubusercontent.com/48297101/154980678-ae9db212-f38b-4a4e-a628-0f94d13086b7.png)
 
 [![maven-central](https://img.shields.io/maven-central/v/xyz.dynxsty/dih4jda.svg)](https://central.sonatype.dev/search?q=dih4jda&sort=name&namespace=xyz.dynxsty)
-[![](https://jitpack.io/v/DynxstyGIT/DIH4JDA.svg)](https://jitpack.io/#DynxstyGIT/DIH4JDA)
+[![](https://jitpack.io/v/DynxstyGIT/DIH4JDA.svg)](https://jitpack.io/#jasonlessenich/DIH4JDA)
 
 
 A fairly easy-to-use command framework for the [Java Discord API](https://github.com/DV8FromTheWorld/JDA), with support for [Slash Commands and Context Commands](https://discord.com/developers/docs/interactions/application-commands)
 
 ## Installation
 
-This version of DIH4JDA **must** be used with [`5.0.0-beta.1`](https://github.com/DV8FromTheWorld/JDA/releases) or 
+This version of DIH4JDA **must** be used with JDA [`6.0.0`](https://github.com/discord-jda/JDA/releases) or 
 higher. <br>
 But it is highly recommended to use the latest version of JDA due to [security issues](https://github.com/DV8FromTheWorld/JDA/issues/2381).
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ fun getProjectProperty(name: String) = project.properties[name] as? String
 
 group = "xyz.dynxsty"
 val archivesBaseName = "dih4jda"
-version = "1.6.2"
+version = "1.7.0"
 
 val javaVersion: JavaVersion = JavaVersion.current()
 var isCI: Boolean = System.getProperty("GIT_COMMIT") != null // jitpack
@@ -57,7 +57,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.11.0")
     testImplementation("ch.qos.logback:logback-classic:1.5.8")
 
-    api("net.dv8tion:JDA:5.1.1") {
+    api("net.dv8tion:JDA:6.0.0") {
         exclude(module = "opus-java")
     }
 

--- a/src/examples/java/xyz/dynxsty/examples/commands/PollCommand.java
+++ b/src/examples/java/xyz/dynxsty/examples/commands/PollCommand.java
@@ -1,10 +1,11 @@
 package xyz.dynxsty.examples.commands;
 
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import org.jetbrains.annotations.NotNull;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import xyz.dynxsty.dih4jda.interactions.components.ButtonHandler;
@@ -27,17 +28,20 @@ public class PollCommand extends SlashCommand implements ButtonHandler {
     public void execute(@Nonnull SlashCommandInteractionEvent event) {
         // Creates a message with buttons.
         event.reply("Choose between these two options!")
-                .addActionRow(Button.primary(ComponentIdBuilder.build("button", "1"), "Option 1"),
-                        Button.secondary(ComponentIdBuilder.build("button", "2"), "Option 2"))
-                .setEphemeral(false).queue();
+            .addComponents(
+                ActionRow.of(
+                    Button.primary(ComponentIdBuilder.build("button", "1"), "Option 1"),
+                    Button.secondary(ComponentIdBuilder.build("button", "2"), "Option 2")
+                )
+            ).setEphemeral(false).queue();
     }
 
     @Override
     public void handleButton(@NotNull ButtonInteractionEvent event, @NotNull Button button) {
         // Handles buttons that were previously mapped using DIH4JDA#addButtonMappings
-        String[] id = ComponentIdBuilder.split(button.getId());
+        String[] id = ComponentIdBuilder.split(button.getCustomId());
         // Splits the buttons' id on the specified separator (in this case ':')
-        if (id[1].equals("1")) {
+        if ("1".equals(id[1])) {
             event.reply("You voted for option 1!").queue();
         } else {
             event.reply("You voted for option 2!").queue();

--- a/src/main/java/xyz/dynxsty/dih4jda/interactions/components/ButtonHandler.java
+++ b/src/main/java/xyz/dynxsty/dih4jda/interactions/components/ButtonHandler.java
@@ -1,7 +1,7 @@
 package xyz.dynxsty.dih4jda.interactions.components;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import xyz.dynxsty.dih4jda.DIH4JDA;
 import xyz.dynxsty.dih4jda.util.ComponentIdBuilder;
 

--- a/src/main/java/xyz/dynxsty/dih4jda/interactions/components/EntitySelectMenuHandler.java
+++ b/src/main/java/xyz/dynxsty/dih4jda/interactions/components/EntitySelectMenuHandler.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 /**
  * An interface that contains the method that should be executed when a user interacts with a
- * {@link net.dv8tion.jda.api.interactions.components.selections.EntitySelectMenu}.
+ * {@link net.dv8tion.jda.api.components.selections.EntitySelectMenu}.
  */
 public interface EntitySelectMenuHandler {
 

--- a/src/main/java/xyz/dynxsty/dih4jda/interactions/components/ModalHandler.java
+++ b/src/main/java/xyz/dynxsty/dih4jda/interactions/components/ModalHandler.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 /**
  * An interface that contains the method that should be executed when a user interacts with a
- * {@link net.dv8tion.jda.api.interactions.modals.Modal}.
+ * {@link net.dv8tion.jda.api.modals.Modal}.
  */
 public interface ModalHandler {
 	/**

--- a/src/main/java/xyz/dynxsty/dih4jda/interactions/components/StringSelectMenuHandler.java
+++ b/src/main/java/xyz/dynxsty/dih4jda/interactions/components/StringSelectMenuHandler.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 /**
  * An interface that contains the method that should be executed when a user interacts with a
- * {@link net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu}.
+ * {@link net.dv8tion.jda.api.components.selections.StringSelectMenu}.
  */
 public interface StringSelectMenuHandler {
 


### PR DESCRIPTION
## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.

### Changes

- [ ] Internal code
- [ ] Documentation
- [ ] Added examples
- [X] Other: Dependency update

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR contains a major version update of JDA to 6.0.0. I've also bumped the version to 1.7.0.

This is a breaking change as JDA packages were renamed. With this change, users of DIH4JDA must use JDA 6.x.y.